### PR TITLE
Make language detection faster

### DIFF
--- a/crawler/executeCrawler.php
+++ b/crawler/executeCrawler.php
@@ -39,9 +39,11 @@ function detectLanguage($page){
     // ************************************************
     // ************************************************
     // Detector de idioma
-    $detector = new LanguageDetector\LanguageDetector();
-    $language = $detector->evaluate($page)->getLanguage();
-    return $language; // Prints something like 'en'
+    // $detector = new LanguageDetector\LanguageDetector();
+    // $language = $detector->evaluate($page)->getLanguage();
+    // return $language; 
+    // Prints something like 'en'
+    return \LanguageDetector\LanguageDetector::detect($page);
 }
 function Singular($page, $lang){
     $language = strval($lang);


### PR DESCRIPTION
Hi @Santiagomrn 

Using `new LanguageDetector()` will force the detector to re-read all subsets from disk everytime you call  `detectLanguage`.
It's enough for a one shot detection. But if you make a lot of calls to your function `detectLanguage`, it will slow down the process.

Using the static call  `\LanguageDetector\LanguageDetector::detect($page)` will only read the subsets once and then no more disk access is needed.